### PR TITLE
fix: macos build error fix

### DIFF
--- a/CascLib/CMakeLists.txt
+++ b/CascLib/CMakeLists.txt
@@ -77,6 +77,10 @@ if(WIN32)
     set(LINK_LIBS wininet)
 endif()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 if(APPLE)
     message(STATUS "Using Mac OS X port")
     set(LINK_LIBS z bz2)
@@ -107,7 +111,7 @@ if(CASC_BUILD_SHARED_LIB)
 	
 	
 if(APPLE)
-    set_target_properties(casc PROPERTIES FRAMEWORK true)
+    set_target_properties(casc PROPERTIES FRAMEWORK false)
     set_target_properties(casc PROPERTIES PUBLIC_HEADER "src/CascLib.h src/CascPort.h")
     set_target_properties(casc PROPERTIES LINK_FLAGS "-framework Carbon")
 endif()
@@ -137,7 +141,7 @@ if(CASC_BUILD_STATIC_LIB)
 	install(TARGETS casc_static RUNTIME DESTINATION bin LIBRARY DESTINATION lib${LIB_SUFFIX} ARCHIVE DESTINATION lib${LIB_SUFFIX} FRAMEWORK DESTINATION /Library/Frameworks)
 	
 	if(APPLE)
-    set_target_properties(casc_static PROPERTIES FRAMEWORK true)
+    set_target_properties(casc_static PROPERTIES FRAMEWORK false)
     set_target_properties(casc_static PROPERTIES PUBLIC_HEADER "src/CascLib.h src/CascPort.h")
     set_target_properties(casc_static PROPERTIES LINK_FLAGS "-framework Carbon")
 endif()


### PR DESCRIPTION
cause ghost uses casclib as lib but not as framework, we need to compile`casc` as lib